### PR TITLE
fix: update Jira search endpoint

### DIFF
--- a/pyJIRAReminder.py
+++ b/pyJIRAReminder.py
@@ -229,7 +229,7 @@ class JiraClient:
         return f'assignee = "{assignee_email}"{proj} AND status CHANGED TO Done DURING (startOfDay(), now()) ORDER BY resolutiondate DESC'
 
     def search(self, jql: str, max_results: int = 50) -> list[dict]:
-        url = f"{self.base}/rest/api/3/search/jql"
+        url = f"{self.base}/rest/api/search/jql"
         payload = {
             "jql": jql,
             "maxResults": max_results,


### PR DESCRIPTION
## Summary
- update the Jira search endpoint to target /rest/api/search/jql per the latest API change

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911049d8e248331bc50e3138b2d934a)